### PR TITLE
Daily view testing

### DIFF
--- a/MoodJournal/frontend/src/DailyView/DailyView.js
+++ b/MoodJournal/frontend/src/DailyView/DailyView.js
@@ -63,35 +63,25 @@ class DailyView extends Component {
             entries: response.data
           });
           return axios.get('/api/categories/')
-        },
-        (error) => {
-          this.setState({
-            isLoaded: true,
-            error
-          });
         }
       )
       .then(
         (response) => {
           this.setState({
-            isLoaded: true, // Need categories for the EntryWidgets.
             categories: response.data
           });
           return axios.get('/api/quality-ratings/')
-        },
-        (error) => {
-          this.setState({
-            isLoaded: true,
-            error
-          });
         }
       )
       .then(
         (response) => {
           this.setState({
+            isLoaded: true, // Need for the widgets.
             qualityRatings: response.data
           });
-        },
+        }
+      )
+      .catch(
         (error) => {
           this.setState({
             isLoaded: true,

--- a/MoodJournal/frontend/src/DailyView/DailyView.test.js
+++ b/MoodJournal/frontend/src/DailyView/DailyView.test.js
@@ -1,0 +1,225 @@
+import React from 'react';
+
+import { createShallow } from 'material-ui/test-utils';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import moment from 'moment';
+
+import DailyView from './DailyView.js';
+import EntryWidget from '../EntryWidget/EntryWidget.js';
+import EntryCreator from '../EntryCreator/EntryCreator.js';
+
+// Not sure how stable this method is... used to pause running until promises resolve.
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+const OLD_DATE = moment('2000-01-01');
+
+const ENTRIES_URL = '/api/entries/?date=' + moment().format('YYYY-MM-DD');
+const CATEGORIES_URL = '/api/categories/';
+const QR_URL = '/api/quality-ratings/';
+const HDC_URL = '/api/entries/?date=' + OLD_DATE.format('YYYY-MM-DD');
+
+
+const ENTRIES_DATA = [
+    {
+        "url": "http://127.0.0.1:8000/api/entries/10/",
+        "category": 16,
+        "date": "2018-01-05",
+        "entry": "I sleep.",
+        "quality_rating": "Good"
+    },
+    {
+        "url": "http://127.0.0.1:8000/api/entries/14/",
+        "category": 15,
+        "date": "2018-02-20",
+        "entry": "Another day another dollar!",
+        "quality_rating": "Good"
+    },
+];
+const CATEGORIES_DATA = [
+    {
+        "url": "http://127.0.0.1:8000/api/categories/17/",
+        "category": "Social",
+        "rank": 10,
+        "pk": 17
+    },
+    {
+      "url": "http://127.0.0.1:8000/api/categories/15/",
+      "category": "Health",
+      "rank": 2,
+      "pk": 15
+    },
+    {
+    "url": "http://127.0.0.1:8000/api/categories/16/",
+    "category": "Sleep",
+    "rank": 1,
+    "pk": 16
+    }
+];
+const QR_DATA = [
+  "Terrible",
+  "Bad",
+  "OK",
+  "Good",
+  "Excellent"
+];
+
+const HDC_DATA = [
+    {
+        "url": "http://127.0.0.1:8000/api/entries/19/",
+        "category": 16,
+        "date": "2018-08-05",
+        "entry": "I sleep ok.",
+        "quality_rating": "Good"
+    },
+];
+
+let mock = new MockAdapter(axios);
+
+mock.onGet(ENTRIES_URL).replyOnce(200, ENTRIES_DATA)
+    .onGet(CATEGORIES_URL).replyOnce(200, CATEGORIES_DATA)
+    .onGet(QR_URL).replyOnce(200, QR_DATA)
+
+    .onGet(ENTRIES_URL).replyOnce(500)
+
+    .onGet(ENTRIES_URL).replyOnce(200, ENTRIES_DATA)
+    .onGet(CATEGORIES_URL).replyOnce(500)
+
+    .onGet(ENTRIES_URL).replyOnce(200, ENTRIES_DATA)
+    .onGet(CATEGORIES_URL).replyOnce(200, CATEGORIES_DATA)
+    .onGet(QR_URL).replyOnce(500)
+
+    .onGet(ENTRIES_URL).reply(200, ENTRIES_DATA)
+    .onGet(CATEGORIES_URL).reply(200, CATEGORIES_DATA)
+    .onGet(QR_URL).reply(200, QR_DATA)
+
+    .onGet(HDC_URL).replyOnce(200, HDC_DATA)
+
+    .onGet(HDC_URL).replyOnce(500);
+
+
+it('renders without crashing', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+});
+
+it('displays an error on GET entries error', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  // console.log(wrapper.state())
+  expect(wrapper.text()).toContain("Error");
+});
+
+it('displays an error on GET categories error', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  // console.log(wrapper.state())
+  expect(wrapper.text()).toContain("Error");
+});
+
+it('displays an error on GET qualityRatings error', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  // console.log(wrapper.state())
+  expect(wrapper.text()).toContain("Error");
+});
+
+it('updates entries upon new date selection', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  expect(wrapper.find(EntryWidget).length).toBe(2);
+  wrapper.instance().handleDateChange(OLD_DATE);
+  await flushPromises();
+  wrapper.update();
+  expect(wrapper.find(EntryWidget).length).toBe(1);
+});
+
+it('displays an error on axios new date selection error', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  wrapper.instance().handleDateChange(OLD_DATE);
+  await flushPromises();
+  wrapper.update();
+  expect(wrapper.text()).toContain("Error");
+});
+
+it('passes state to EntryWidget', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  let ew = wrapper.find(EntryWidget).first();
+  const entry = wrapper.instance().state.entries[0];
+  expect(ew.prop('url')).toBe(entry.url);
+  expect(ew.prop('date')).toBe(entry.date);
+  expect(ew.prop('rating')).toBe(entry.quality_rating);
+  expect(ew.prop('entry')).toBe(entry.entry);
+  expect(ew.prop('category')).toBe(wrapper.instance().getCategoryName(entry.category));
+});
+
+it('passes methods to EntryWidget', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  let ew = wrapper.find(EntryWidget).first();
+  expect(ew.prop('handleDelete')).toBe(wrapper.instance().handleDelete);
+  expect(ew.prop('handleSave')).toBe(wrapper.instance().handleUpdate);
+});
+
+it('passes state to EntryCreator', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  let ec = wrapper.find(EntryCreator);
+  const state = wrapper.instance().state;
+  expect(ec.prop('date')).toBe(moment().format('YYYY-MM-DD'));
+  expect(ec.prop('qualityRatings')).toBe(state.qualityRatings);
+  expect(ec.prop('categories')).toEqual(wrapper.instance().getUnusedCategories());
+});
+
+it('passes method to EntryCreator', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  let ec = wrapper.find(EntryCreator);
+  expect(ec.prop('handleSave')).toBe(wrapper.instance().handleCreate);
+});
+
+it('categories filterer test', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  const category = [
+    {
+        "url": "http://127.0.0.1:8000/api/categories/17/",
+        "category": "Social",
+        "rank": 10,
+        "pk": 17
+    },
+  ]
+  expect(wrapper.instance().getUnusedCategories()).toEqual(category);
+});
+
+it('getCategoryName test', async () => {
+  let shallow = createShallow({untilSelector: DailyView});
+  const wrapper = shallow(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+  expect(wrapper.instance().getCategoryName(17)).toBe('Social');
+});

--- a/MoodJournal/frontend/src/EntryEditor/EntryEditor.test.js
+++ b/MoodJournal/frontend/src/EntryEditor/EntryEditor.test.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Typography from 'material-ui/Typography';
+import TextField from 'material-ui/TextField';
+import Button from 'material-ui/Button';
+
+import EntryEditor from './EntryEditor.js';
+
+const setup = propOverrides => {
+  const props = Object.assign({
+    date: '2018-01-01',
+    qualityRatings: ['Good', 'OK', 'Bad'],
+    handleCancel: jest.fn(),
+    handleSave: jest.fn()
+  }, propOverrides);
+
+  const wrapper = shallow(<EntryEditor {...props} />);
+
+  return wrapper;
+}
+
+const POSTprops = {categories: [{pk: 1, category: 'cat'}]};
+const PATCHprops = {category: 'cat', url: 'path/to/stuff', rating: 'OK', entry: 'my entry'};
+
+it('renders POST without crashing', () => {
+  setup(POSTprops);
+});
+
+it('renders PATCH without crashing', () => {
+  setup(PATCHprops);
+});
+
+it('displays a category if PATCH', () => {
+  const wrapper = setup(PATCHprops);
+  let text = wrapper.find(Typography).at(1);
+  expect(text.contains('cat')).toBeTruthy();
+});
+
+it('displays three editable widgets (TextField) in POST', () => {
+  const wrapper = setup(POSTprops);
+  let textfields = wrapper.find(TextField);
+  expect(textfields.length).toBe(3);
+});
+
+it('displays two editable widgets (TextField) in PATCH', () => {
+  const wrapper = setup(PATCHprops);
+  let textfields = wrapper.find(TextField);
+  expect(textfields.length).toBe(2);
+});
+
+it('displays a date', () => {
+  const wrapper = setup(PATCHprops);
+  let text = wrapper.find(Typography).at(0);
+  expect(text.contains('2018-01-01')).toBeTruthy();
+  const wrapper2 = setup(POSTprops);
+  let text2 = wrapper2.find(Typography).at(0);
+  expect(text2.contains('2018-01-01')).toBeTruthy();
+});
+
+it('calls handleCancel on Cancel btn click', () => {
+  let wrapper = setup(POSTprops);
+  let cancelBtn = wrapper.find(Button).last();
+  cancelBtn.simulate('click');
+  let handleCancel = wrapper.instance().props.handleCancel;
+  expect(handleCancel.mock.calls.length).toEqual(1);
+});
+
+it('handles POST saving upon clicking the Save button', () => {
+  let wrapper = setup(POSTprops);
+  let saveBtn = wrapper.find(Button).first();
+  saveBtn.simulate('click');
+  let handleSave = wrapper.instance().props.handleSave;
+  expect(handleSave.mock.calls.length).toEqual(1);
+});
+
+it('handles PATCH saving upon clicking the Save button', () => {
+  let wrapper = setup(PATCHprops);
+  let saveBtn = wrapper.find(Button).first();
+  saveBtn.simulate('click');
+  let handleSave = wrapper.instance().props.handleSave;
+  expect(handleSave.mock.calls.length).toEqual(1);
+});
+
+it('Updates state upon entry text editor change', () => {
+  let wrapper = setup(POSTprops);
+  let textField = wrapper.find(TextField).last();
+  textField.simulate('change', {
+    target: {
+      value: "ab"
+    }
+  });
+  expect(wrapper.state('entry')).toBe('ab');
+});
+
+it('Save button enabled toggles if content changed or not', () => {
+  let wrapper = setup(POSTprops);
+  let saveBtn = wrapper.find(Button).first();
+  expect(saveBtn.prop('disabled')).toBeTruthy();
+  let textField = wrapper.find(TextField).last();
+  textField.simulate('change', {
+    target: {
+      value: "ab"
+    }
+  });
+  let saveBtn2 = wrapper.find(Button).first();
+  expect(saveBtn2.prop('disabled')).toBeFalsy();
+  textField.simulate('change', {
+    target: {
+      value: ""
+    }
+  });
+  let saveBtn3 = wrapper.find(Button).first();
+  expect(saveBtn3.prop('disabled')).toBeTruthy();
+});

--- a/MoodJournal/frontend/src/EntryWidget/EntryWidget.test.js
+++ b/MoodJournal/frontend/src/EntryWidget/EntryWidget.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { createShallow } from 'material-ui/test-utils';
+
+import { CardContent } from 'material-ui/Card';
+import Button from 'material-ui/Button';
+
+import EntryEditor from '../EntryEditor/EntryEditor.js';
+import EntryWidget from './EntryWidget.js';
+
+
+const setup = propOverrides => {
+  const props = Object.assign({
+    date: '2018-01-01',
+    category: 'Dummy',
+    rating: 'OK',
+    entry: 'Todays entry',
+    url: 'path/to/resource',
+    qualityRatings: ['Good', 'OK', 'Bad'],
+    handleDelete: jest.fn(),
+    handleSave: jest.fn(),
+  }, propOverrides);
+
+  let shallow = createShallow();
+  const wrapper = shallow(<EntryWidget {...props} />);
+  return wrapper;
+};
+
+it('renders without crashing', () => {
+  setup();
+});
+
+it('default displays the date', () => {
+  let wrapper = setup();
+  let cc = wrapper.find(CardContent).dive();
+  // console.log(cc.containsMatchingElement('Dummy')); //true as well
+  expect(cc.contains('2018-01-01')).toBeTruthy();
+});
+
+it('default displays the category', () => {
+  let wrapper = setup();
+  let cc = wrapper.find(CardContent).dive();
+  expect(cc.contains('Dummy')).toBeTruthy();
+});
+
+it('default displays the rating', () => {
+  let wrapper = setup();
+  let cc = wrapper.find(CardContent).dive();
+  expect(cc.contains('OK')).toBeTruthy();
+});
+
+it('default displays the entry', () => {
+  let wrapper = setup();
+  let cc = wrapper.find(CardContent).dive();
+  expect(cc.contains('Todays entry')).toBeTruthy();
+});
+
+it('calls toggle upon Edit Btn click', () => {
+  //ref: https://github.com/airbnb/enzyme/issues/944
+  const spy = jest.spyOn(EntryWidget.prototype, 'toggleState');
+  let wrapper = setup();
+  let editBtn = wrapper.find(Button).at(0);
+  editBtn.simulate('click');
+  expect(spy).toHaveBeenCalled();
+});
+
+it('calls DELETE upon delete btn click', () => {
+  let wrapper = setup();
+  let deleteBtn = wrapper.find(Button).at(1);
+  deleteBtn.simulate('click');
+  let handleDelete = wrapper.instance().props.handleDelete;
+  expect(handleDelete.mock.calls.length).toBe(1);
+});
+
+it('displays an EntryEditor upon Edit button click', () => {
+  let wrapper = setup();
+  let editBtn = wrapper.find(Button).at(0);
+  editBtn.simulate('click');
+  let ee = wrapper.find(EntryEditor);
+  expect(ee.length).toBe(1);
+});
+
+it('passes props to EntryEditor', () => {
+  let wrapper = setup();
+  let editBtn = wrapper.find(Button).at(0);
+  editBtn.simulate('click');
+  let ee = wrapper.find(EntryEditor);
+  expect(ee.prop('url')).toBe(wrapper.instance().props.url);
+  expect(ee.prop('date')).toBe(wrapper.instance().props.date);
+  expect(ee.prop('category')).toBe(wrapper.instance().props.category);
+  expect(ee.prop('handleSave')).toBe(wrapper.instance().props.handleSave);
+  expect(ee.prop('qualityRatings')).toBe(wrapper.instance().props.qualityRatings);
+  expect(ee.prop('rating')).toBe(wrapper.instance().props.rating);
+  expect(ee.prop('entry')).toBe(wrapper.instance().props.entry);
+  expect(ee.prop('handleCancel')).toBe(wrapper.instance().toggleState);
+});

--- a/MoodJournal/frontend/src/tests/DailyView.int.test.js
+++ b/MoodJournal/frontend/src/tests/DailyView.int.test.js
@@ -1,0 +1,231 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import moment from 'moment';
+
+import TextField from 'material-ui/TextField';
+
+import DailyView from '../DailyView/DailyView.js';
+import EntryWidget from '../EntryWidget/EntryWidget.js';
+import EntryCreator from '../EntryCreator/EntryCreator.js';
+import EntryEditor from '../EntryEditor/EntryEditor.js';
+
+
+const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+const BASE_ENTRIES_URL = '/api/entries/';
+const ENTRIES_URL = '/api/entries/?date=' + moment().format('YYYY-MM-DD');
+const CATEGORIES_URL = '/api/categories/';
+const QR_URL = '/api/quality-ratings/';
+const BASEPOST = '/api/entries/';
+
+const ENTRIES_DATA = [
+    {
+        "url": "http://127.0.0.1:8000/api/entries/10/",
+        "category": 16,
+        "date": "2018-01-05",
+        "entry": "I sleep.",
+        "quality_rating": "Good"
+    },
+    {
+        "url": "http://127.0.0.1:8000/api/entries/14/",
+        "category": 15,
+        "date": "2018-02-20",
+        "entry": "Another day another dollar!",
+        "quality_rating": "Good"
+    },
+];
+const CATEGORIES_DATA = [
+    {
+        "url": "http://127.0.0.1:8000/api/categories/17/",
+        "category": "Social",
+        "rank": 10,
+        "pk": 17
+    },
+    {
+      "url": "http://127.0.0.1:8000/api/categories/15/",
+      "category": "Health",
+      "rank": 2,
+      "pk": 15
+    },
+    {
+    "url": "http://127.0.0.1:8000/api/categories/16/",
+    "category": "Sleep",
+    "rank": 1,
+    "pk": 16
+    }
+];
+const QR_DATA = [
+  "Terrible",
+  "Bad",
+  "OK",
+  "Good",
+  "Excellent"
+];
+
+let mock = new MockAdapter(axios);
+
+mock.onGet(ENTRIES_URL).reply(200, ENTRIES_DATA)
+    .onGet(CATEGORIES_URL).reply(200, CATEGORIES_DATA)
+    .onGet(QR_URL).reply(200, QR_DATA);
+
+mock.onPost(BASE_ENTRIES_URL).replyOnce(201, {
+      "url": "http://127.0.0.1:8000/api/entries/69/",
+      "category": 15,
+      "date": "2018-04-20",
+      "entry": "New Entry!",
+      "quality_rating": "Good"
+});
+
+mock.onPatch("http://127.0.0.1:8000/api/entries/10/").replyOnce(200, {
+      "url": "http://127.0.0.1:8000/api/entries/10/",
+      "category": 16,
+      "date": "2018-01-05",
+      "entry": "sleep.",
+      "quality_rating": "Good"
+    })
+// Error testing.
+    .onPatch("http://127.0.0.1:8000/api/entries/10/").replyOnce(400, {
+    "category": [
+        "An entry for this category on this date already exists."
+    ]
+})
+    .onPatch("http://127.0.0.1:8000/api/entries/10/").replyOnce(400, {
+    "entry": [
+        "Ensure this field has no more than 5000 characters."
+    ]
+});
+
+mock.onDelete("http://127.0.0.1:8000/api/entries/10/").replyOnce(204)
+    .onDelete("http://127.0.0.1:8000/api/entries/10/").replyOnce(500);
+
+it('renders without crashing', async () => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+});
+//        "An entry for this category on this date already exists."
+//        "Ensure this field has no more than 5000 characters."
+
+it('can add new entries', async () => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ec = wrapper.find(EntryCreator);
+  ec.instance().toggleState({});
+  wrapper.update();
+
+  let ee = wrapper.find(EntryEditor);
+  ee.instance().handleChange('category')({target: {value: 'Health'}})
+  ee.instance().handleChange('rating')({target: {value: 'Good'}})
+  ee.instance().handleChange('entry')({target: {value: 'New entry created.'}})
+  wrapper.update();
+
+  ee = wrapper.find(EntryEditor);
+  ee.instance().routeSave({}); // {} acts as empty error arg.
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.find(EntryWidget).length).toBe(3);
+  expect(wrapper.find(EntryEditor).length).toBe(0);
+});
+
+it('can edit a preexisting entry', async () => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ew = wrapper.find(EntryWidget).first();
+  ew.instance().toggleState({});
+  wrapper.update();
+
+  let ee = wrapper.find(EntryEditor);
+  ee.instance().handleChange('entry')({target: {value: 'entry modified.'}})
+  wrapper.update();
+
+  ee = wrapper.find(EntryEditor);
+
+  ee.instance().routeSave({});
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.find(EntryWidget).length).toBe(2);
+  expect(wrapper.find(EntryEditor).length).toBe(0);
+});
+
+// NB: these two error tests just test the display (via state examination),
+// NOT, the actual Django functionality (mocked axios response)
+it('displays error on saving with preexisting category', async() => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ew = wrapper.find(EntryWidget).first();
+  ew.instance().toggleState({});
+  wrapper.update();
+
+  let ee = wrapper.find(EntryEditor);
+  ee.instance().handleChange('entry')({target: {value: 'entry modified.'}})
+  wrapper.update();
+
+  ee = wrapper.find(EntryEditor);
+
+  ee.instance().routeSave({});
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.find(EntryEditor).length).toBe(1);
+  expect(wrapper.find(EntryEditor).instance().state.categoryError).toBeTruthy();
+});
+
+it('displays error on saving >5000 char entry', async() => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ew = wrapper.find(EntryWidget).first();
+  ew.instance().toggleState({});
+  wrapper.update();
+
+  let ee = wrapper.find(EntryEditor);
+  ee.instance().handleChange('entry')({target: {value: 'entry modified.'}})
+  wrapper.update();
+
+  ee = wrapper.find(EntryEditor);
+
+  ee.instance().routeSave({});
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.find(EntryEditor).length).toBe(1);
+  expect(wrapper.find(EntryEditor).instance().state.entryError).toBeTruthy();
+});
+
+// Delete tests
+it('can delete entries', async () => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ew = wrapper.find(EntryWidget).first();
+  ew.instance().props.handleDelete(ew.instance().props.url);
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.find(EntryWidget).length).toBe(1);
+});
+
+it('displays error on delete error', async () => {
+  const wrapper = mount(<DailyView />);
+  await flushPromises();
+  wrapper.update();
+
+  let ew = wrapper.find(EntryWidget).first();
+  ew.instance().props.handleDelete(ew.instance().props.url);
+  await flushPromises();
+  wrapper.update();
+
+  expect(wrapper.text()).toContain("Error");
+});


### PR DESCRIPTION
Looking at the coverage metrics for my modules seems to highlight some
of the limitations of coverage metrics. In particular, I have achieved
good numbers for my EntryCreator widget, in spite of not writing a
single unit test for it. I have also retained poor % Branch metrics for
the DailyView widget. While this is true, the branches are all just
like ‘else (default error message)’ which I suppose I *should* test,
but don’t feel like writing all that code for. I have also noticed that
coverage does not indicate props passing correctness or things of that
ilk, which makes sense, but is just something to keep in mind.