### PR TITLE
Email

### DIFF
--- a/MoodJournal/MoodJournal/settings/base.py
+++ b/MoodJournal/MoodJournal/settings/base.py
@@ -131,7 +131,12 @@ REST_FRAMEWORK = {
 
 }
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_HOST = 'smtp.mailgun.org'
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587
+EMAIL_HOST_USER = 'postmaster@mg.categoricaljournal.com'
+EMAIL_HOST_PASSWORD = get_env_variable('EMAIL_HOST_PASSWORD')
 
 # Configure the JWTs to expire after 1 hour, and allow users to refresh near-expiration tokens
 JWT_AUTH = {

--- a/MoodJournal/templates/account/email/email_confirmation_signup_message.txt
+++ b/MoodJournal/templates/account/email/email_confirmation_signup_message.txt
@@ -1,0 +1,15 @@
+{% load account %}
+{% user_display user as user_display %}
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from Category Journal!
+
+You're receiving this e-mail because user {{ user_display }} has given yours as an e-mail address to connect their account.
+
+To confirm this is correct, go to {{ activate_url }}
+
+If you did not sign up with Category Journal, ignore this email.
+{% endblocktrans %}{% endautoescape %}
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you from Category Journal!
+{{ site_domain }}
+{% endblocktrans %}

--- a/MoodJournal/templates/account/email/email_confirmation_signup_subject.txt
+++ b/MoodJournal/templates/account/email/email_confirmation_signup_subject.txt
@@ -1,0 +1,3 @@
+{% autoescape off %}
+Please Confirm Your E-mail Address
+{% endautoescape %}

--- a/MoodJournal/templates/account/email/password_reset_key_message.txt
+++ b/MoodJournal/templates/account/email/password_reset_key_message.txt
@@ -1,0 +1,13 @@
+{% load i18n %}
+{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Hello from Category Journal!
+
+You're receiving this e-mail because you or someone else has requested a password for your user account.
+It can be safely ignored if you did not request a password reset. Click the link below to reset your password.{% endblocktrans %}
+
+{{ password_reset_url }}
+
+{% if username %}{% blocktrans %}In case you forgot, your username is {{ username }}.{% endblocktrans %}
+
+{% endif %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}Thank you for using Category Journal!
+{{ site_domain }}
+{% endblocktrans %}

--- a/MoodJournal/templates/account/email/password_reset_key_subject.txt
+++ b/MoodJournal/templates/account/email/password_reset_key_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password Reset E-mail{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
TODO: there is a bug where the password reset message is using the
default. I do not know where this default is located. It is not
password_reset_key_message.txt